### PR TITLE
chore(python-version): Move to python 3.9 and up because 3.8 is close…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         # Python versions in nox testing environment
-        python-version: ['3.8', "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@
 
 import nox
 
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "lod_unit"
 description = "A simple python library with an astropy unit for λ/D"
 authors = [{ name = "Corey Spohn", email = "corey.a.spohn@nasa.gov" }]
 dynamic = ['readme', 'version']
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 classifiers = [
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
… to EOL